### PR TITLE
Fix JWT token description in Swagger setup

### DIFF
--- a/ReservaFacil.API/Program.cs
+++ b/ReservaFacil.API/Program.cs
@@ -28,7 +28,7 @@ builder.Services.AddSwaggerGen(options =>
         Scheme = "Bearer",
         BearerFormat = "JWT",
         In = Microsoft.OpenApi.Models.ParameterLocation.Header,
-        Description = "Insira o TOken JWT assim: **Bearer {seu token}**"
+        Description = "Insira o Token JWT assim: **Bearer {seu token}**"
     });
 
     options.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement{


### PR DESCRIPTION
## Summary
- correct capitalization of "Token" in Swagger security definition

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684984514ee48321a9842cda5e77d6e8