### PR TITLE
Fix password length attribute

### DIFF
--- a/ReservaFacil.Application/DTOs/Usuario/UsuarioInputDto.cs
+++ b/ReservaFacil.Application/DTOs/Usuario/UsuarioInputDto.cs
@@ -15,7 +15,7 @@ public class UsuarioInputDto
     public String Email { get; set; } = string.Empty;
 
     [Required]
-    [StringLength(100, ErrorMessage = "A senha deve ter no máximo 16 caracteres.")]
+    [StringLength(16, ErrorMessage = "A senha deve ter no máximo 16 caracteres.")]
     [MinLength(6, ErrorMessage = "A senha deve ter no mínimo 6 caracteres.")]
     public String Senha { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Summary
- fix `UsuarioInputDto.Senha` StringLength max value

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498545842c8321ad054d0f1b7663c8