### PR TITLE
Add integration tests for API controllers

### DIFF
--- a/ReservaFacil.API/Program.cs
+++ b/ReservaFacil.API/Program.cs
@@ -126,3 +126,5 @@ app.UseExceptionHandlerMiddleware();
 app.MapControllers();
 
 app.Run();
+
+public partial class Program { }

--- a/ReservaFacil.Tests/Integration/ApiTests.cs
+++ b/ReservaFacil.Tests/Integration/ApiTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Enums;
+using ReservaFacil.Infrastructure.Data;
+using Xunit;
+
+namespace ReservaFacil.Tests.Integration
+{
+    public class ApiTests : IClassFixture<CustomWebApplicationFactory>
+    {
+        private readonly HttpClient _client;
+        private readonly CustomWebApplicationFactory _factory;
+
+        public ApiTests(CustomWebApplicationFactory factory)
+        {
+            _factory = factory;
+            _client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task GetEspacos_ReturnsOk()
+        {
+            using (var scope = _factory.Services.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+                db.Espacos.Add(new Espaco
+                {
+                    Id = Guid.NewGuid(),
+                    Nome = "Teste",
+                    Descricao = "Desc",
+                    Capacidade = 1,
+                    TipoEspaco = TipoEspaco.Auditorio,
+                    Disponivel = true
+                });
+                db.SaveChanges();
+            }
+
+            var response = await _client.GetAsync("/api/Espaco");
+
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/ReservaFacil.Tests/Integration/AuthControllerIntegrationTests.cs
+++ b/ReservaFacil.Tests/Integration/AuthControllerIntegrationTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ReservaFacil.Application.DTOs;
+using ReservaFacil.Application.DTOs.Login;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Enums;
+using ReservaFacil.Infrastructure.Data;
+using Xunit;
+
+namespace ReservaFacil.Tests.Integration;
+
+public class AuthControllerIntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public AuthControllerIntegrationTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Login_ReturnsToken()
+    {
+        var email = $"user{Guid.NewGuid()}@test.com";
+        var password = "123456";
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+            db.Usuarios.Add(new Usuario
+            {
+                Id = Guid.NewGuid(),
+                Nome = "User",
+                Email = email,
+                SenhaHash = BCrypt.Net.BCrypt.HashPassword(password),
+                TipoUsuario = TipoUsuario.UsuarioComum
+            });
+            db.SaveChanges();
+        }
+
+        var response = await _client.PostAsJsonAsync("/api/Auth/login", new { Email = email, Senha = password });
+        response.EnsureSuccessStatusCode();
+        var data = await response.Content.ReadFromJsonAsync<ApiResponse<LoginOutputDto>>();
+        Assert.False(string.IsNullOrEmpty(data!.Dados.Token));
+    }
+}

--- a/ReservaFacil.Tests/Integration/CustomWebApplicationFactory.cs
+++ b/ReservaFacil.Tests/Integration/CustomWebApplicationFactory.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using ReservaFacil.Infrastructure.Data;
+
+namespace ReservaFacil.Tests.Integration
+{
+    public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+
+            builder.ConfigureAppConfiguration((context, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    {"Jwt:Key", "TestKey123456789012345678901234567890"},
+                    {"Jwt:Issuer", "TestIssuer"}
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ReservaFacilDbContext>));
+                if (descriptor != null)
+                    services.Remove(descriptor);
+
+                services.AddDbContext<ReservaFacilDbContext>(options =>
+                {
+                    options.UseInMemoryDatabase("InMemoryTest" + Guid.NewGuid());
+                });
+
+                var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+                db.Database.EnsureCreated();
+            });
+        }
+    }
+}

--- a/ReservaFacil.Tests/Integration/EspacoControllerIntegrationTests.cs
+++ b/ReservaFacil.Tests/Integration/EspacoControllerIntegrationTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ReservaFacil.Application.DTOs;
+using ReservaFacil.Application.DTOs.Espaco;
+using ReservaFacil.Application.DTOs.Login;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Enums;
+using ReservaFacil.Infrastructure.Data;
+using Xunit;
+
+namespace ReservaFacil.Tests.Integration;
+
+public class EspacoControllerIntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public EspacoControllerIntegrationTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task<string> GetAdminTokenAsync()
+    {
+        var email = $"admin{Guid.NewGuid()}@test.com";
+        var password = "adminpass";
+        return await TestHelper.CreateUserAndLoginAsync(_client, _factory.Services, email, password, TipoUsuario.Administrador);
+    }
+
+    [Fact]
+    public async Task GetEspacoPorId_ReturnsOk()
+    {
+        Guid id;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+            var espaco = new Espaco
+            {
+                Id = Guid.NewGuid(),
+                Nome = "Sala X",
+                Descricao = "Desc",
+                Capacidade = 5,
+                TipoEspaco = TipoEspaco.Coworking,
+                Disponivel = true
+            };
+            db.Espacos.Add(espaco);
+            db.SaveChanges();
+            id = espaco.Id;
+        }
+
+        var response = await _client.GetAsync($"/api/Espaco/{id}");
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task CriarAtualizarDeletarEspaco_Flow()
+    {
+        var token = await GetAdminTokenAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var input = new EspacoInputDto { Nome = "SalaTest", Descricao = "Desc", Capacidade = 10, TipoEspaco = "SalaDeReuniao" };
+        var createResponse = await _client.PostAsJsonAsync("/api/Espaco", input);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var created = await createResponse.Content.ReadFromJsonAsync<ApiResponse<EspacoOutputDto>>();
+        var id = created!.Dados.Id;
+
+        input.Nome = "SalaAtualizada";
+        var updateResponse = await _client.PutAsJsonAsync($"/api/Espaco/{id}", input);
+        updateResponse.EnsureSuccessStatusCode();
+
+        var deleteResponse = await _client.DeleteAsync($"/api/Espaco/{id}");
+        deleteResponse.EnsureSuccessStatusCode();
+    }
+}

--- a/ReservaFacil.Tests/Integration/ReservaControllerIntegrationTests.cs
+++ b/ReservaFacil.Tests/Integration/ReservaControllerIntegrationTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ReservaFacil.Application.DTOs;
+using ReservaFacil.Application.DTOs.Reserva;
+using ReservaFacil.Application.DTOs.Espaco;
+using ReservaFacil.Application.DTOs.Usuario;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Enums;
+using ReservaFacil.Infrastructure.Data;
+using Xunit;
+
+namespace ReservaFacil.Tests.Integration;
+
+public class ReservaControllerIntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public ReservaControllerIntegrationTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private static DateTime GetValidStartDate()
+    {
+        var date = DateTime.Now.AddDays(3);
+        while (date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+            date = date.AddDays(1);
+        return new DateTime(date.Year, date.Month, date.Day, 9, 0, 0);
+    }
+
+    [Fact]
+    public async Task CriarReserva_ReturnsCreated()
+    {
+        Guid userId;
+        Guid espacoId;
+        var start = GetValidStartDate();
+        var end = start.AddHours(2);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+            var user = new Usuario
+            {
+                Id = Guid.NewGuid(),
+                Nome = "Usu",
+                Email = "u" + Guid.NewGuid() + "@test.com",
+                SenhaHash = BCrypt.Net.BCrypt.HashPassword("123456"),
+                TipoUsuario = TipoUsuario.UsuarioComum
+            };
+            db.Usuarios.Add(user);
+            var espaco = new Espaco
+            {
+                Id = Guid.NewGuid(),
+                Nome = "Sala R",
+                Descricao = "Desc",
+                Capacidade = 5,
+                TipoEspaco = TipoEspaco.Coworking,
+                Disponivel = true
+            };
+            db.Espacos.Add(espaco);
+            db.SaveChanges();
+            userId = user.Id;
+            espacoId = espaco.Id;
+        }
+
+        var token = await TestHelper.CreateUserAndLoginAsync(_client, _factory.Services, "login" + Guid.NewGuid() + "@test.com", "123456", TipoUsuario.UsuarioComum);
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var dto = new ReservaInputDto
+        {
+            UsuarioId = userId,
+            EspacoId = espacoId,
+            DataInicio = start,
+            DataFim = end,
+            StatusReserva = "Pendente"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/Reserva", dto);
+        Assert.Equal(System.Net.HttpStatusCode.Created, response.StatusCode);
+    }
+}

--- a/ReservaFacil.Tests/Integration/TestHelper.cs
+++ b/ReservaFacil.Tests/Integration/TestHelper.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ReservaFacil.Application.DTOs;
+using ReservaFacil.Application.DTOs.Login;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Enums;
+using ReservaFacil.Infrastructure.Data;
+
+namespace ReservaFacil.Tests.Integration;
+
+internal static class TestHelper
+{
+    public static async Task<string> CreateUserAndLoginAsync(HttpClient client, IServiceProvider services, string email, string password, TipoUsuario tipo)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+        db.Usuarios.Add(new Usuario
+        {
+            Id = Guid.NewGuid(),
+            Nome = "TestUser",
+            Email = email,
+            SenhaHash = BCrypt.Net.BCrypt.HashPassword(password),
+            TipoUsuario = tipo
+        });
+        db.SaveChanges();
+
+        var response = await client.PostAsJsonAsync("/api/Auth/login", new { Email = email, Senha = password });
+        response.EnsureSuccessStatusCode();
+        var apiResponse = await response.Content.ReadFromJsonAsync<ApiResponse<LoginOutputDto>>();
+        return apiResponse!.Dados.Token;
+    }
+}

--- a/ReservaFacil.Tests/Integration/UsuarioControllerIntegrationTests.cs
+++ b/ReservaFacil.Tests/Integration/UsuarioControllerIntegrationTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using ReservaFacil.Application.DTOs.Usuario;
+using ReservaFacil.Domain.Enums;
+using Xunit;
+
+namespace ReservaFacil.Tests.Integration;
+
+public class UsuarioControllerIntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public UsuarioControllerIntegrationTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task<string> GetAdminTokenAsync()
+    {
+        var email = $"admin{Guid.NewGuid()}@test.com";
+        var password = "adminpass";
+        return await TestHelper.CreateUserAndLoginAsync(_client, _factory.Services, email, password, TipoUsuario.Administrador);
+    }
+
+    [Fact]
+    public async Task CriarEObterUsuario_Flow()
+    {
+        var createDto = new UsuarioInputDto { Nome = "Novo Usuario", Email = $"user{Guid.NewGuid()}@test.com", Senha = "123456", TipoUsuario = "UsuarioComum" };
+        var createResponse = await _client.PostAsJsonAsync("/api/Usuario", createDto);
+        createResponse.EnsureSuccessStatusCode();
+        var created = await createResponse.Content.ReadFromJsonAsync<ApiResponse<UsuarioOutputDto>>();
+        var id = created!.Dados.Id;
+
+        var token = await GetAdminTokenAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var getResponse = await _client.GetAsync($"/api/Usuario/{id}");
+        getResponse.EnsureSuccessStatusCode();
+    }
+}

--- a/ReservaFacil.Tests/ReservaFacil.Tests.csproj
+++ b/ReservaFacil.Tests/ReservaFacil.Tests.csproj
@@ -6,4 +6,21 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ReservaFacil.API/ReservaFacil.API.csproj" />
+    <ProjectReference Include="../ReservaFacil.Application/ReservaFacil.Application.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/ReservaFacil.Tests/Unit/Controllers/AuthControllerTests.cs
+++ b/ReservaFacil.Tests/Unit/Controllers/AuthControllerTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReservaFacil.API.Controllers;
+using ReservaFacil.Application.DTOs;
+using ReservaFacil.Application.DTOs.Login;
+using ReservaFacil.Application.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Controllers
+{
+    public class AuthControllerTests
+    {
+        [Fact]
+        public void Login_ReturnsOk_WhenCredentialsValid()
+        {
+            // Arrange
+            var serviceMock = new Mock<IAuthService>();
+            var loggerMock = new Mock<ILogger<AuthController>>();
+            var input = new LoginInputDto { Email = "test@test.com", Senha = "123" };
+            var output = new LoginOutputDto { Id = Guid.NewGuid(), Token = "token" };
+            serviceMock.Setup(s => s.Login(input)).Returns(output);
+            var controller = new AuthController(serviceMock.Object, loggerMock.Object);
+
+            // Act
+            var result = controller.Login(input);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<ApiResponse<LoginOutputDto>>(okResult.Value);
+            Assert.Equal(output.Token, response.Dados.Token);
+        }
+
+        [Fact]
+        public void Login_ReturnsUnauthorized_WhenServiceReturnsNull()
+        {
+            var serviceMock = new Mock<IAuthService>();
+            var loggerMock = new Mock<ILogger<AuthController>>();
+            var input = new LoginInputDto { Email = "test@test.com", Senha = "123" };
+            serviceMock.Setup(s => s.Login(input)).Returns((LoginOutputDto?)null);
+            var controller = new AuthController(serviceMock.Object, loggerMock.Object);
+
+            var result = controller.Login(input);
+
+            Assert.IsType<UnauthorizedObjectResult>(result);
+        }
+    }
+}

--- a/ReservaFacil.Tests/Unit/Controllers/EspacoControllerTests.cs
+++ b/ReservaFacil.Tests/Unit/Controllers/EspacoControllerTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReservaFacil.API.Controllers;
+using ReservaFacil.Application.DTOs.Espaco;
+using ReservaFacil.Application.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Controllers
+{
+    public class EspacoControllerTests
+    {
+        [Fact]
+        public void Criar_ReturnsCreated_WhenSuccess()
+        {
+            var serviceMock = new Mock<IEspacoService>();
+            var logger = new Mock<ILogger<EspacoController>>();
+            var input = new EspacoInputDto { Nome = "Sala", Descricao = "desc", Capacidade = 10, TipoEspaco = "Auditorio" };
+            var output = new EspacoOutputDto { Id = Guid.NewGuid(), Nome = "Sala" };
+            serviceMock.Setup(s => s.Criar(input)).Returns(output);
+            var controller = new EspacoController(serviceMock.Object, logger.Object);
+
+            var result = controller.Criar(input);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+    }
+}

--- a/ReservaFacil.Tests/Unit/Controllers/ReservaControllerTests.cs
+++ b/ReservaFacil.Tests/Unit/Controllers/ReservaControllerTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReservaFacil.API.Controllers;
+using ReservaFacil.Application.DTOs.Reserva;
+using ReservaFacil.Application.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Controllers
+{
+    public class ReservaControllerTests
+    {
+        [Fact]
+        public void ObterReservaPorId_InvalidId_ReturnsBadRequest()
+        {
+            var serviceMock = new Mock<IReservaService>();
+            var logger = new Mock<ILogger<ReservaController>>();
+            var controller = new ReservaController(serviceMock.Object, logger.Object);
+
+            var result = controller.ObterReservaPorId(Guid.Empty);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public void ListarReservas_ReturnsOkWithData()
+        {
+            var serviceMock = new Mock<IReservaService>();
+            var logger = new Mock<ILogger<ReservaController>>();
+            serviceMock.Setup(s => s.Listar()).Returns(new List<ReservaOutputDto>());
+            var controller = new ReservaController(serviceMock.Object, logger.Object);
+
+            var result = controller.ListarReservas();
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+    }
+}

--- a/ReservaFacil.Tests/Unit/Controllers/UsuarioControllerTests.cs
+++ b/ReservaFacil.Tests/Unit/Controllers/UsuarioControllerTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReservaFacil.API.Controllers;
+using ReservaFacil.Application.DTOs.Usuario;
+using ReservaFacil.Application.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Controllers
+{
+    public class UsuarioControllerTests
+    {
+        [Fact]
+        public void CriarUsuario_ReturnsCreated_WhenSuccess()
+        {
+            var serviceMock = new Mock<IUsuarioService>();
+            var logger = new Mock<ILogger<UsuarioController>>();
+            var input = new UsuarioInputDto { Nome = "User", Email = "u@test.com", Senha = "123456", TipoUsuario = "Administrador" };
+            var output = new UsuarioOutputDto { Id = Guid.NewGuid(), Nome = "User" };
+            serviceMock.Setup(s => s.Criar(input)).Returns(output);
+            var controller = new UsuarioController(serviceMock.Object, logger.Object);
+
+            var result = controller.CriarUsuario(input);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+    }
+}

--- a/ReservaFacil.Tests/Unit/Services/AuthServiceTests.cs
+++ b/ReservaFacil.Tests/Unit/Services/AuthServiceTests.cs
@@ -1,0 +1,30 @@
+using System;
+using AutoMapper;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using ReservaFacil.Application.DTOs.Login;
+using ReservaFacil.Application.Services;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Infrastructure.Data.Repositories.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Services
+{
+    public class AuthServiceTests
+    {
+        [Fact]
+        public void Login_ReturnsNull_WhenUserNotFound()
+        {
+            var repo = new Mock<IUsuarioRepository>();
+            var mapper = new Mock<IMapper>();
+            var tokenService = new Mock<ITokenService>();
+            var config = new Mock<IConfiguration>();
+            repo.Setup(r => r.ObterPorEmail("none@test.com")).Returns((Usuario?)null);
+            var service = new AuthService(repo.Object, config.Object, mapper.Object, tokenService.Object);
+
+            var result = service.Login(new LoginInputDto { Email = "none@test.com", Senha = "123" });
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/ReservaFacil.Tests/Unit/Services/EspacoServiceTests.cs
+++ b/ReservaFacil.Tests/Unit/Services/EspacoServiceTests.cs
@@ -1,0 +1,36 @@
+using System;
+using AutoMapper;
+using Moq;
+using ReservaFacil.Application.DTOs.Espaco;
+using ReservaFacil.Application.Mappings;
+using ReservaFacil.Application.Services;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Exceptions;
+using ReservaFacil.Infrastructure.Data.Repositories.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Services
+{
+    public class EspacoServiceTests
+    {
+        private readonly IMapper _mapper;
+
+        public EspacoServiceTests()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<EspacoProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public void Criar_ShouldThrow_WhenNomeExists()
+        {
+            var repo = new Mock<IEspacoRepository>();
+            repo.Setup(r => r.ObterPorNome("Sala"))
+                .Returns(new Espaco { Id = Guid.NewGuid(), Nome = "Sala" });
+            var service = new EspacoService(_mapper, repo.Object);
+            var dto = new EspacoInputDto { Nome = "Sala", Descricao = "", Capacidade = 1, TipoEspaco = "Auditorio" };
+
+            Assert.Throws<BusinessException>(() => service.Criar(dto));
+        }
+    }
+}

--- a/ReservaFacil.Tests/Unit/Services/ReservaServiceTests.cs
+++ b/ReservaFacil.Tests/Unit/Services/ReservaServiceTests.cs
@@ -1,0 +1,28 @@
+using System;
+using AutoMapper;
+using Moq;
+using ReservaFacil.Application.DTOs.Reserva;
+using ReservaFacil.Application.Services;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Exceptions;
+using ReservaFacil.Infrastructure.Data.Repositories.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Services
+{
+    public class ReservaServiceTests
+    {
+        [Fact]
+        public void Deletar_ShouldThrowNotFound_WhenReservaNaoExiste()
+        {
+            var repo = new Mock<IReservaRepository>();
+            repo.Setup(r => r.ObterPorId(It.IsAny<Guid>())).Returns((Reserva?)null);
+            var usuarioService = new Mock<IUsuarioService>();
+            var espacoService = new Mock<IEspacoService>();
+            var mapper = new Mock<IMapper>();
+            var service = new ReservaService(repo.Object, usuarioService.Object, espacoService.Object, mapper.Object);
+
+            Assert.Throws<NotFoundException>(() => service.Deletar(Guid.NewGuid()));
+        }
+    }
+}

--- a/ReservaFacil.Tests/Unit/Services/UsuarioServiceTests.cs
+++ b/ReservaFacil.Tests/Unit/Services/UsuarioServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using AutoMapper;
+using Moq;
+using ReservaFacil.Application.DTOs.Usuario;
+using ReservaFacil.Application.Mappings;
+using ReservaFacil.Application.Services;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Infrastructure.Data.Repositories.Interfaces;
+using Xunit;
+
+namespace ReservaFacil.Tests.Unit.Services
+{
+    public class UsuarioServiceTests
+    {
+        private readonly IMapper _mapper;
+
+        public UsuarioServiceTests()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<UsuarioProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public void Criar_ShouldThrow_WhenEmailExists()
+        {
+            var repo = new Mock<IUsuarioRepository>();
+            repo.Setup(r => r.ObterPorEmail("exist@test.com")).Returns(new Usuario { Id = Guid.NewGuid() });
+            var service = new UsuarioService(repo.Object, _mapper);
+            var dto = new UsuarioInputDto { Nome = "User", Email = "exist@test.com", Senha = "123456", TipoUsuario = "Administrador" };
+
+            Assert.Throws<ValidationException>(() => service.Criar(dto));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- configure CustomWebApplicationFactory with in-memory JWT settings
- add helper to create users and login during tests
- create integration tests for EspacoController actions
- create integration tests for AuthController
- create integration tests for ReservaController and UsuarioController

## Testing
- `dotnet test ReservaFacil.Tests/ReservaFacil.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684997f31df883218e393466998d3278