### PR TITLE
Add SpecFlow BDD test project

### DIFF
--- a/ReservaFacil.BddTests/CustomWebApplicationFactory.cs
+++ b/ReservaFacil.BddTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReservaFacil.Infrastructure.Data;
+
+namespace ReservaFacil.Tests.Integration
+{
+    public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+    {
+                // Isso é executado antes do Program.CreateBuilder()
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            // 1) Garante que o IHostEnvironment.EnvironmentName == "Testing"
+            builder.UseEnvironment("Testing");
+
+            // 2) Agora o Program.cs, ao fazer builder.Environment.IsEnvironment("Testing"),
+            //    vai cair na ramificação do InMemory e NÃO registrar o SQL Server.
+
+            return base.CreateHost(builder);
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+                db.Database.EnsureDeleted();
+                db.Database.EnsureCreated();
+            });
+        }
+    }
+}

--- a/ReservaFacil.BddTests/Features/Autenticacao.feature
+++ b/ReservaFacil.BddTests/Features/Autenticacao.feature
@@ -1,0 +1,35 @@
+# language: pt
+Funcionalidade: Autenticação
+  Como usuário da API
+  Quero efetuar login com credenciais válidas
+  Para receber um token JWT
+
+  Contexto:
+    Dado que existe um usuário cadastrado com email "user@test.com" e senha "P@ssw0rd"
+
+  @sucesso
+  Cenário: Login com credenciais válidas
+    Quando eu enviar um POST para "/api/auth/login" com o body:
+      """
+      {
+        "email": "user@test.com",
+        "password": "P@ssw0rd"
+      }
+      """
+    Então o status da resposta deve ser 200
+    E o corpo da resposta deve conter um campo "token" não vazio
+
+  @erro
+  Cenário: Login com credenciais inválidas
+    Quando eu enviar um POST para "/api/auth/login" com o body:
+      """
+      {
+        "email": "user@test.com",
+        "password": "senhaErrada"
+      }
+      """
+    Então o status da resposta deve ser 401
+    E o corpo da resposta deve conter:
+      """
+      { "error": "Credenciais inválidas" }
+      """

--- a/ReservaFacil.BddTests/Features/Espaco.feature
+++ b/ReservaFacil.BddTests/Features/Espaco.feature
@@ -1,0 +1,49 @@
+# language: pt
+Funcionalidade: Gerenciamento de Espaços
+  Como cliente da API
+  Quero consultar e manipular registros de espaços
+
+  @sucesso
+  Cenário: Buscar espaço existente por ID
+    Dado que existe um espaço com ID 42 e nome "Sala A"
+    Quando eu enviar um GET para "/api/espacos/42"
+    Então o status da resposta deve ser 200
+    E o corpo deve conter:
+      """
+      { "id": 42, "nome": "Sala A" }
+      """
+
+  @erro
+  Cenário: Buscar espaço inexistente
+    Quando eu enviar um GET para "/api/espacos/9999"
+    Então o status da resposta deve ser 404
+    E o corpo deve conter:
+      """
+      { "error": "Espaço não encontrado" }
+      """
+
+  @sucesso
+  Cenário: Criar novo espaço com dados válidos
+    Quando eu enviar um POST para "/api/espacos" com o body:
+      """
+      {
+        "nome": "Sala B",
+        "capacidade": 10
+      }
+      """
+    Então o status da resposta deve ser 201
+    E o header "Location" deve apontar para "/api/espacos/{id}"
+
+  @erro
+  Cenário: Criar espaço sem nome
+    Quando eu enviar um POST para "/api/espacos" com o body:
+      """
+      {
+        "capacidade": 10
+      }
+      """
+    Então o status da resposta deve ser 400
+    E o corpo deve conter:
+      """
+      { "errors": { "Nome": "O campo Nome é obrigatório" } }
+      """

--- a/ReservaFacil.BddTests/Features/Reserva.feature
+++ b/ReservaFacil.BddTests/Features/Reserva.feature
@@ -1,0 +1,44 @@
+# language: pt
+Funcionalidade: Reserva de Espaços
+  Como usuário autenticado
+  Quero criar reservas sem conflito de horário
+
+  Contexto:
+    Dado que existe um espaço com ID 42
+
+  @sucesso
+  Cenário: Criar reserva em horário livre
+    Dado que estou autenticado com token válido
+    Quando eu enviar um POST para "/api/reservas" com o body:
+      """
+      {
+        "espacoId": 42,
+        "usuarioId": 1,
+        "dataHoraInicio": "2025-07-01T10:00:00",
+        "dataHoraFim":    "2025-07-01T11:00:00"
+      }
+      """
+    Então o status da resposta deve ser 201
+    E o corpo deve conter algo como:
+      """
+      { "id": 100, "espacoId": 42, "usuarioId": 1 }
+      """
+
+  @erro
+  Cenário: Criar reserva em horário já reservado
+    Dado que já existe uma reserva no espaço 42 entre "2025-07-01T10:00:00" e "2025-07-01T11:00:00"
+    Dado que estou autenticado com token válido
+    Quando eu enviar um POST para "/api/reservas" com o body:
+      """
+      {
+        "espacoId": 42,
+        "usuarioId": 2,
+        "dataHoraInicio": "2025-07-01T10:30:00",
+        "dataHoraFim":    "2025-07-01T11:30:00"
+      }
+      """
+    Então o status da resposta deve ser 409
+    E o corpo deve conter:
+      """
+      { "error": "Horário já reservado" }
+      """

--- a/ReservaFacil.BddTests/Features/Usuario.feature
+++ b/ReservaFacil.BddTests/Features/Usuario.feature
@@ -1,0 +1,37 @@
+# language: pt
+Funcionalidade: Usuário
+  Como administrador
+  Quero cadastrar e consultar usuários
+
+  @sucesso
+  Cenário: Cadastrar usuário válido
+    Quando eu enviar um POST para "/api/usuarios" com o body:
+      """
+      {
+        "nome": "João",
+        "email": "joao@test.com",
+        "senha": "P@ss1234"
+      }
+      """
+    Então o status da resposta deve ser 201
+    E o corpo deve conter algo como:
+      """
+      { "id": 1, "nome": "João", "email": "joao@test.com" }
+      """
+
+  @erro
+  Cenário: Cadastrar usuário com email já existente
+    Dado que já existe um usuário com email "joao@test.com"
+    Quando eu enviar um POST para "/api/usuarios" com o body:
+      """
+      {
+        "nome": "João2",
+        "email": "joao@test.com",
+        "senha": "OutraSenha1"
+      }
+      """
+    Então o status da resposta deve ser 409
+    E o corpo deve conter:
+      """
+      { "error": "Email já cadastrado" }
+      """

--- a/ReservaFacil.BddTests/ReservaFacil.BddTests.csproj
+++ b/ReservaFacil.BddTests/ReservaFacil.BddTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.9.74" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" PrivateAssets="all" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ReservaFacil.API/ReservaFacil.API.csproj" />
+  </ItemGroup>
+</Project>

--- a/ReservaFacil.BddTests/Steps/ApiSteps.cs
+++ b/ReservaFacil.BddTests/Steps/ApiSteps.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using TechTalk.SpecFlow;
+using ReservaFacil.API;
+using ReservaFacil.Infrastructure.Data;
+using ReservaFacil.Domain.Entities;
+using ReservaFacil.Domain.Enums;
+using ReservaFacil.Application.DTOs;
+using ReservaFacil.Application.DTOs.Login;
+
+namespace ReservaFacil.BddTests.Steps;
+
+[Binding]
+public class ApiSteps
+{
+    private readonly CustomWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private HttpResponseMessage? _response;
+
+    public ApiSteps()
+    {
+        _factory = new CustomWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    private IServiceProvider Services => _factory.Services;
+
+    [Given(@"que existe um usuário cadastrado com email \"(.*)\" e senha \"(.*)\"")]
+    public void GivenExistingUser(string email, string senha)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+        db.Usuarios.Add(new Usuario
+        {
+            Id = Guid.NewGuid(),
+            Nome = "User",
+            Email = email,
+            SenhaHash = BCrypt.Net.BCrypt.HashPassword(senha),
+            TipoUsuario = TipoUsuario.UsuarioComum
+        });
+        db.SaveChanges();
+    }
+
+    [Given(@"que existe um espaço com ID (\d+) e nome \"(.*)\"")]
+    public void GivenExistingSpace(int id, string nome)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+        var guid = IntToGuid(id);
+        db.Espacos.Add(new Espaco
+        {
+            Id = guid,
+            Nome = nome,
+            Descricao = "desc",
+            Capacidade = 10,
+            TipoEspaco = TipoEspaco.Coworking,
+            Disponivel = true
+        });
+        db.SaveChanges();
+    }
+
+    [Given(@"já existe um usuário com email \"(.*)\"")]
+    public void GivenExistingUserEmail(string email)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+        db.Usuarios.Add(new Usuario
+        {
+            Id = Guid.NewGuid(),
+            Nome = "User",
+            Email = email,
+            SenhaHash = BCrypt.Net.BCrypt.HashPassword("123456"),
+            TipoUsuario = TipoUsuario.UsuarioComum
+        });
+        db.SaveChanges();
+    }
+
+    [Given(@"já existe uma reserva no espaço (\d+) entre \"(.*)\" e \"(.*)\"")]
+    public void GivenExistingReservation(int id, string inicio, string fim)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+        var espacoId = IntToGuid(id);
+        var usuario = new Usuario
+        {
+            Id = Guid.NewGuid(),
+            Nome = "User",
+            Email = $"u{Guid.NewGuid()}@test.com",
+            SenhaHash = BCrypt.Net.BCrypt.HashPassword("123456"),
+            TipoUsuario = TipoUsuario.UsuarioComum
+        };
+        db.Usuarios.Add(usuario);
+        db.Reservas.Add(new Reserva
+        {
+            Id = Guid.NewGuid(),
+            UsuarioId = usuario.Id,
+            EspacoId = espacoId,
+            DataInicio = DateTime.Parse(inicio),
+            DataFim = DateTime.Parse(fim),
+            StatusReserva = "Pendente"
+        });
+        db.SaveChanges();
+    }
+
+    [Given(@"existe um espaço com ID (\d+)")]
+    public void GivenSpaceWithId(int id)
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+        var guid = IntToGuid(id);
+        if (!db.Espacos.Any(e => e.Id == guid))
+        {
+            db.Espacos.Add(new Espaco
+            {
+                Id = guid,
+                Nome = $"Sala {id}",
+                Descricao = "desc",
+                Capacidade = 10,
+                TipoEspaco = TipoEspaco.Coworking,
+                Disponivel = true
+            });
+            db.SaveChanges();
+        }
+    }
+
+    [Given(@"estou autenticado com token válido")]
+    public async Task GivenAuthenticated()
+    {
+        var email = $"user{Guid.NewGuid()}@test.com";
+        var password = "P@ssw0rd";
+        using (var scope = Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ReservaFacilDbContext>();
+            db.Usuarios.Add(new Usuario
+            {
+                Id = Guid.NewGuid(),
+                Nome = "User",
+                Email = email,
+                SenhaHash = BCrypt.Net.BCrypt.HashPassword(password),
+                TipoUsuario = TipoUsuario.UsuarioComum
+            });
+            db.SaveChanges();
+        }
+        var login = await _client.PostAsJsonAsync("/api/Auth/login", new { Email = email, Senha = password });
+        login.EnsureSuccessStatusCode();
+        var data = await login.Content.ReadFromJsonAsync<ApiResponse<LoginOutputDto>>();
+        var token = data!.Dados.Token;
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    [When(@"eu enviar um GET para \"(.*)\"")]
+    public async Task WhenGet(string url)
+    {
+        _response = await _client.GetAsync(url);
+    }
+
+    [When(@"eu enviar um POST para \"(.*)\" com o body:")]
+    public async Task WhenPostWithBody(string url, string body)
+    {
+        _response = await _client.PostAsync(url, new StringContent(body, Encoding.UTF8, "application/json"));
+    }
+
+    [Then(@"o status da resposta deve ser (\d+)")]
+    public void ThenStatusCode(int status)
+    {
+        ((int)_response!.StatusCode).Should().Be(status);
+    }
+
+    [Then(@"o corpo da resposta deve conter um campo \"(.*)\" não vazio")]
+    public async Task ThenBodyHasField(string field)
+    {
+        var json = await _response!.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var token = doc.RootElement.GetProperty("dados").GetProperty(field).GetString();
+        token.Should().NotBeNullOrEmpty();
+    }
+
+    [Then(@"o corpo da resposta deve conter:")]
+    public async Task ThenBodyContains(string expected)
+    {
+        var json = await _response!.Content.ReadAsStringAsync();
+        json.Should().Contain(expected.Trim());
+    }
+
+    [Then(@"o corpo deve conter:")]
+    public async Task ThenBodyContainsAlt(string expected)
+    {
+        await ThenBodyContains(expected);
+    }
+
+    [Then(@"o header \"(.*)\" deve apontar para \"(.*)\"")]
+    public void ThenHeaderLocation(string header, string value)
+    {
+        _response!.Headers.Location!.ToString().Should().Contain(value.Trim('{', '}'));
+    }
+
+    private static Guid IntToGuid(int id)
+    {
+        return new Guid($"00000000-0000-0000-0000-{id.ToString().PadLeft(12, '0')}");
+    }
+}

--- a/ReservaFacil.sln
+++ b/ReservaFacil.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReservaFacil.Infrastructure
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReservaFacil.Tests", "ReservaFacil.Tests\ReservaFacil.Tests.csproj", "{758490F2-B197-498F-8E9A-B1F52DC42DD7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReservaFacil.BddTests", "ReservaFacil.BddTests\ReservaFacil.BddTests.csproj", "{C94DF4D9-B3F8-4BC9-9521-BC1747309BCD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{758490F2-B197-498F-8E9A-B1F52DC42DD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{758490F2-B197-498F-8E9A-B1F52DC42DD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{758490F2-B197-498F-8E9A-B1F52DC42DD7}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C94DF4D9-B3F8-4BC9-9521-BC1747309BCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C94DF4D9-B3F8-4BC9-9521-BC1747309BCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C94DF4D9-B3F8-4BC9-9521-BC1747309BCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C94DF4D9-B3F8-4BC9-9521-BC1747309BCD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a new project `ReservaFacil.BddTests` with SpecFlow for BDD scenarios
- include `.feature` files describing authentication, space management, users and reservations
- implement step definitions that reuse a custom `WebApplicationFactory`
- update the solution to include the BDD test project

## Testing
- `dotnet test ReservaFacil.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a244b0b088321a68b223e504947cf